### PR TITLE
主にTreeのフォントサイズを変更

### DIFF
--- a/.atom/styles.less
+++ b/.atom/styles.less
@@ -17,7 +17,8 @@
 
 // style the background color of the tree view
 .tree-view {
-  // background-color: whitesmoke;
+//background-color: whitesmoke;
+font-size: 14px;
 }
 
 // style the background and foreground colors on the atom-text-editor-element itself
@@ -29,4 +30,21 @@ atom-text-editor {
 // style UI elements inside atom-text-editor
 atom-text-editor .cursor {
   // border-color: red;
+}
+
+//検索結果をハイライト
+atom-text-editor::shadow {
+  .gutter .cursor-line {
+    background-color: fade(skyblue, 40%);
+  }
+  .highlights {
+    .selection .region {
+      border: 1px solid fade(crimson, 30%);
+      background: fade(crimson, 20%);
+    }
+    .find-result .region {
+      border: 1px solid fade(cyan, 30%);
+      background: fade(cyan, 20%);
+    }
+  }
 }


### PR DESCRIPTION
Treeのフォントサイズが見づらくていよいよ発狂しそうになったので、情報収集して変更。
13インチの解像度2048x1280で使用中。

## 参考にさせていただいたサイト
- Atomで選択範囲の背景色を見やすく変更する
http://blog.nocorica.jp/2015/06/atom-selection-color/
- カラーネーム140色－WEBカラーリファレンス
http://www.htmq.com/color/colorname.shtml
- Atom ツリーのフォントサイズを変更する｜WEB系技術電脳日記
https://ameblo.jp/konica/entry-12098807495.html