### PR TITLE
「atom-text-editor::shadow」は旧書式なので新しい書式にします

### DIFF
--- a/.atom/styles.less
+++ b/.atom/styles.less
@@ -17,34 +17,29 @@
 
 // style the background color of the tree view
 .tree-view {
-//background-color: whitesmoke;
 font-size: 14px;
 }
 
-// style the background and foreground colors on the atom-text-editor-element itself
-atom-text-editor {
-  // color: white;
-  // background-color: hsl(180, 24%, 12%);
-}
-
-// style UI elements inside atom-text-editor
-atom-text-editor .cursor {
-  // border-color: red;
-}
 
 //検索結果をハイライト
-atom-text-editor::shadow {
-  .gutter .cursor-line {
-    background-color: fade(skyblue, 40%);
-  }
-  .highlights {
-    .selection .region {
-      border: 1px solid fade(crimson, 30%);
-      background: fade(crimson, 20%);
+atom-text-editor.editor {
+    .gutter {
+        .cursor-line {
+            background-color: fade(skyblue, 40%);
+        }
     }
-    .find-result .region {
-      border: 1px solid fade(cyan, 30%);
-      background: fade(cyan, 20%);
+    .highlights {
+        .selection {
+            .region {
+                border: 1px solid fade(crimson, 30%);
+                background: fade(crimson, 20%);
+            }
+        }
+        .find-result {
+            .region {
+                border: 1px solid fade(cyan, 30%);
+                background: fade(cyan, 20%);
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
### 参考にしたページ
- atom-text-editor::shadow は廃止されました（ATOM v1.13.0） - ハトネコエ Web がくしゅうちょう
http://nekonenene.hatenablog.com/entry/2017/01/20/193707
- Removing Shadow DOM styles
http://flight-manual.atom.io/shadow-dom/sections/removing-shadow-dom-styles/